### PR TITLE
Fix typo (recommenation => recommendation)

### DIFF
--- a/process.md
+++ b/process.md
@@ -26,9 +26,9 @@ Readers should note that this document is not a legal document, it does not repl
   * [Voting](#voting)
   * [Closing a Group](#closing-a-group)
 * [W3C Recommendations and Notes](#w3c-recommendations-and-notes)
-  * [Requirements for W3C Recommenations](#requirements-for-w3c-recommenations-technical-reports)
+  * [Requirements for W3C Recommendations](#requirements-for-w3c-recommendations-technical-reports)
   * [Editors](#editors)
-  * [W3C Recommenation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommenation-technical-report-flow-the-recommendation-track)
+  * [W3C Recommendation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommendation-technical-report-flow-the-recommendation-track)
   * [Maturity Levels Explained](#maturity-levels-explained)
   * [Transition Requests and Moving Between Recommendation Track Stages](#transition-requests-and-moving-between-recommendation-track-stages)
   * [Reviewing Documents and Wide Review](#reviewing-documents-and-wide-review)
@@ -97,7 +97,7 @@ Use this list to quick link to a section of this document. Or, scroll past it to
 * __Public Participant__: See [Participants](#participants)
 * __Rec__: See [W3C Recommendation](#w3c-recommendation)
 * __Recommendation__: See [W3C Recommendation](#w3c-recommendation)
-* __Recommendation Track__: See [W3C Recommenation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommenation-technical-report-flow-the-recommendation-track)
+* __Recommendation Track__: See [W3C Recommendation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommendation-technical-report-flow-the-recommendation-track)
 * __Reference Draft__: latest Working Draft published within 90 days of the First Public Working Draft or if no Public Working Draft __:
 * __Rescinded Recommendation__: See [Rescinded, Obsolete or Superseded Recommendations](#rescinded-obsolete-or-superseded-recommendations)
 * __Revised Candidate Recommendation__: See [Revised Candidate Recommendation](#revised-candidate-recommendations)
@@ -182,7 +182,7 @@ The [AC](#advisory-committee-ac) will review new or modified Working and Interes
 After the review has ended, [The Director](#the-director) will announce the results of the review detailing support and any formal objections. The proposal could be: approved, approved with changes, returned for further work or rejected. Please consult the [W3C Process Document](https://www.w3.org/Consortium/Process/#ACReview) for a break down of each of these.
 
 ### AC Appeals
-The [AC](#advisory-committee-ac) can appeal W3C decisions. This is rare. Appeals are usually related to Working or Interest Group creation or modification, or a document progressing through the [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track). For a fuller list of decisions which can be appealed please see the [W3C Process Document](https://www.w3.org/Consortium/Process/#ACAppeal).
+The [AC](#advisory-committee-ac) can appeal W3C decisions. This is rare. Appeals are usually related to Working or Interest Group creation or modification, or a document progressing through the [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track). For a fuller list of decisions which can be appealed please see the [W3C Process Document](https://www.w3.org/Consortium/Process/#ACAppeal).
 
 Appeals must start within three weeks of the a decision. AC Members send an appeal to the [Team](#the-w3c-team), the Team then announce this appeal to the AC allowing the AC to support the appeal if they wish. 
 
@@ -352,14 +352,14 @@ All W3C Recommendations can be found in the [index of W3C technical reports](htt
 
 W3C Groups can also publish **W3C Notes** which are not Recommendation Track documents. Examples of W3C Notes include: lists of use cases, guidance, status of abandonded work, etc.  
 
-W3C Notes also follow the [The Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track). They are usually declared as notes in **Publication of zero or more revised Public Working Drafts:** stage. 
+W3C Notes also follow the [The Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track). They are usually declared as notes in **Publication of zero or more revised Public Working Drafts:** stage. 
 
 For more information please see the [W3C Process Document](https://www.w3.org/Consortium/Process/#Note).
 
-## Requirements for W3C Recommenations (Technical Reports)
-W3C Recommenations (Technical Reports) are public documents at every stage of the [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track). The document will display a set information including:
+## Requirements for W3C Recommendations (Technical Reports)
+W3C Recommendations (Technical Reports) are public documents at every stage of the [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track). The document will display a set information including:
 
-* The document's maturity level (see [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track))
+* The document's maturity level (see [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track))
 * The Working Group who developed the document
 * Instructions on how and where to file bugs
 * "Next Steps" for the document
@@ -367,9 +367,9 @@ W3C Recommenations (Technical Reports) are public documents at every stage of th
 * Explanation of changes from the previous document version (a "Change Log").
 
 ## Editors
-Every W3C Recommenation (Technical Report) will have one or more Editors. These Editors are responsible for writing a document in a way which reflects the decisions of the Working Group. All Editors must be members of the Working Group responsible for the document they are editing. 
+Every W3C Recommendation (Technical Report) will have one or more Editors. These Editors are responsible for writing a document in a way which reflects the decisions of the Working Group. All Editors must be members of the Working Group responsible for the document they are editing. 
 
-## W3C Recommenation (Technical Report) Flow: The "Recommendation Track" 
+## W3C Recommendation (Technical Report) Flow: The "Recommendation Track" 
 A typical flow of a document from draft to Technical Report is below:
 
 ![Recommendation Track Diagram](https://github.com/w3c/wg-effectiveness/blob/master/images/rectrackdiagram.png)
@@ -409,7 +409,7 @@ When a Working Group has agreed to begin work on a new standard or W3C Note they
 
 A Working Group then continues to work on this document, coming to consensus on decisions and editing the document to continue to create "Revised Working Drafts". If significant changes to the document have been made the group should be re-uploaded the document to the [W3C Technical Reports Page](https://www.w3.org/TR/). A Revised Working Draft will need to uploaded also if 6 months pass with no change; this Revised Draft indicates why there has been no change within this time.  
 
-The group will have to prepare some information on the Working Draft for a transition to the next Recommendation Track stage  (see [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track) and [Transition Requests](#transition-requests-and-moving-between-track-stages) for more information on stages and transtions); these include:
+The group will have to prepare some information on the Working Draft for a transition to the next Recommendation Track stage  (see [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track) and [Transition Requests](#transition-requests-and-moving-between-track-stages) for more information on stages and transtions); these include:
 
 * Recordings of the Group decision to advance the document
 * Record of the changes from the last version
@@ -422,7 +422,7 @@ For all Working Drafts a Working Group will document outstanding issues and issu
 Working Drafts can transition to become "Revised Working Drafts", ["Candidate Recommendation"](#candidate-recommendation) or "Working Group Note".
 
 ### Candidate Recommendation
-Candidate Recommendations are documents which are in their final review. At this stage the group will prepare a set of information to progress the document to the next stage (see [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track) and [Transition Requests](#transition-requests-and-moving-between-track-stages) for more information on stages and transtions). The information to be collected is:
+Candidate Recommendations are documents which are in their final review. At this stage the group will prepare a set of information to progress the document to the next stage (see [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track) and [Transition Requests](#transition-requests-and-moving-between-track-stages) for more information on stages and transtions). The information to be collected is:
 
 * Explanation of how the document meets the Working Group requirements (outlined in the [Charter](#charter-and-call-for-participation)) or why the requirements have changed
 * Dependencies on other specifications
@@ -455,7 +455,7 @@ For more information please see the [W3C Process Document](https://www.w3.org/Co
 Substantive edits cannot happen on Proposed Recommendations, so to make any changes the document will move back to being a ["Working Draft"](#working-draft) or a ["Candidate Recommendation"](#candidate-recommendation). Otherwise it can become a ["W3C Recommendation"](#w3c-recommendation) or "Working Group Note".
 
 ### W3C Recommendation
-The W3C Recommendation is an approved standard of the W3C and the end of the [W3C Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track)! There are many informal terms used for a W3C Recommedation including "Rec", "Recommendation", "TR", "Technical Report", "Spec", "Standard"; they all mean the same thing.
+The W3C Recommendation is an approved standard of the W3C and the end of the [W3C Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track)! There are many informal terms used for a W3C Recommedation including "Rec", "Recommendation", "TR", "Technical Report", "Spec", "Standard"; they all mean the same thing.
 
 To get to W3C Recommendation a "W3C Decision" is required; this is where a document has met all the [Transition Request](#transition-requests-and-moving-between-track-stages) requirements, the [Director](#the-director) has approved the document and the document has passed [AC Review](#ac-reviews) during the ["Proposed Recommendation"](#proposed-recommendation) stage. 
 
@@ -513,11 +513,11 @@ Errors may be found in a document after it has progressed to W3C Recommendation.
 
 If a Working Group has already closed, then the W3C can request the change. 
 
-Editorial changes can be progressed without going back to another stage in the [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track). [Substantive changes](https://www.w3.org/Consortium/Process/#substantive-change) can require the document to go back to [Candidate Recommendation](#candidate-recommendation) or, when a Working Group no longer exists, a "Candidate Amended Recommendation".
+Editorial changes can be progressed without going back to another stage in the [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track). [Substantive changes](https://www.w3.org/Consortium/Process/#substantive-change) can require the document to go back to [Candidate Recommendation](#candidate-recommendation) or, when a Working Group no longer exists, a "Candidate Amended Recommendation".
 
 If the Working Group edited the document the recommendation becomes an "Edited Recommendation". If the W3C requested and completed the changes the document becomes an "Amended Recommendation". 
 
-All [Transition Request](#transition-requests-and-moving-between-track-stages) requirements apply to revised recommendations as they do for any other stage of the [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track).
+All [Transition Request](#transition-requests-and-moving-between-track-stages) requirements apply to revised recommendations as they do for any other stage of the [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track).
 
 ### Rescinded, Obsolete or Superseded Recommendations
 The W3C could decide that a W3C Recommendation is no longer recommended. There are three ways of categorising these Recommendations which have become non-recommended:
@@ -533,9 +533,9 @@ The document will then be replublished as an Obsolete or Rescinded Recommendatio
 If only a part of a W3C Recommendation needs to be obsoleted, superceded or rescinded then the document must go through the [Revised Recommendation](#revised-recommendation-edited-and-amended-recommendations) process. 
 
 # Member Submissions
-Members can make document submissions to the W3C. These documents usually detail a technology or other ideas applicable to the Web. These documents have been developed outside the W3C, so they have not gone through the W3C [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track) and are not [W3C Recommendations](#w3c-recommendation). They can become a basis of future work, but there is no guarentee of this.
+Members can make document submissions to the W3C. These documents usually detail a technology or other ideas applicable to the Web. These documents have been developed outside the W3C, so they have not gone through the W3C [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track) and are not [W3C Recommendations](#w3c-recommendation). They can become a basis of future work, but there is no guarentee of this.
 
-Member Submissions are a good way to build support for new work proposals for an upcoming Working Group; if a Working Group already exists it is preferable that technology is contributed through the Working Group as normal and follows the [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track) rather than as a Member Submission.
+Member Submissions are a good way to build support for new work proposals for an upcoming Working Group; if a Working Group already exists it is preferable that technology is contributed through the Working Group as normal and follows the [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track) rather than as a Member Submission.
 
 Only one member makes a Member Submission, even if more than one member worked on the original documents. Strict processes are involved in making a Member Submission, please see the W3C Process Document on [Information Required in a Submission Request](https://www.w3.org/Consortium/Process/#SubmissionReqs) and [Submitter Rights](https://www.w3.org/Consortium/Process/#SubmissionRights). 
 

--- a/process_jp.md
+++ b/process_jp.md
@@ -29,9 +29,9 @@
   * [Voting](#voting)
   * [Closing a Group](#closing-a-group)
 * [W3C Recommendations and Notes](#w3c-recommendations-and-notes)
-  * [Requirements for W3C Recommenations](#requirements-for-w3c-recommenations-technical-reports)
+  * [Requirements for W3C Recommendations](#requirements-for-w3c-recommendations-technical-reports)
   * [Editors](#editors)
-  * [W3C Recommenation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommenation-technical-report-flow-the-recommendation-track)
+  * [W3C Recommendation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommendation-technical-report-flow-the-recommendation-track)
   * [Maturity Levels Explained](#maturity-levels-explained)
   * [Transition Requests and Moving Between Recommendation Track Stages](#transition-requests-and-moving-between-recommendation-track-stages)
   * [Reviewing Documents and Wide Review](#reviewing-documents-and-wide-review)
@@ -100,7 +100,7 @@ W3Cの主要な言語は、仕様テキスト用の英語(米国英語)です。
 * __公的な参加者__:  [Participants](#participants)参照
 * __勧告　Rec__:  [W3C Recommendation](#w3c-recommendation)参照
 * __勧告__:  [W3C Recommendation](#w3c-recommendation)参照
-* __勧告の流れ__:  [W3C Recommenation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommenation-technical-report-flow-the-recommendation-track)参照
+* __勧告の流れ__:  [W3C Recommendation (Technical Report) Flow: The "Recommendation Track"](#w3c-recommendation-technical-report-flow-the-recommendation-track)参照
 * __参照ドラフト__: 最新のワーキングドラフトは最初の公になったワーキングドラフトから90日以内に出版しなければならない
 * __無効勧告__:  [Rescinded, Obsolete or Superseded Recommendations](#rescinded-obsolete-or-superseded-recommendations)参照
 * __修正された候補勧告__:  [Revised Candidate Recommendation](#revised-candidate-recommendations)参照
@@ -191,7 +191,7 @@ ACメンバーシップと責任の詳細については、[W3Cプロセスド�
 
 ### AC Appeals
 ### 異議申し立て
-[AC](#advisory-committee-ac)は、W3Cの決定に異議申し立てすることができます。 これはまれです。 異議申し立ては通常、ワーキンググループまたはインタレストグループの作成または変更、または[Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track)を通じて進行中のドキュメントに関連しています。 アピールできるかどうかの完全なリストについては、[W3Cプロセス文書](https://w3c.github.io/w3process/#ACAppeal)を参照してください。
+[AC](#advisory-committee-ac)は、W3Cの決定に異議申し立てすることができます。 これはまれです。 異議申し立ては通常、ワーキンググループまたはインタレストグループの作成または変更、または[Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track)を通じて進行中のドキュメントに関連しています。 アピールできるかどうかの完全なリストについては、[W3Cプロセス文書](https://w3c.github.io/w3process/#ACAppeal)を参照してください。
 
 異議申し立ては、決定後3週間以内に開始する必要があります。 ACメンバーは[チーム](#the-w3c-team)に異議申し立てを報告し、チームはACにこの異議申し立てをアナウンスして、ACが望む場合に異議申し立てをサポートできるようにします。
 
@@ -383,15 +383,15 @@ W3C勧告は、認知されているW3C標準（「技術報告書」とも呼�
 
 W3Cグループは、勧告トラック文書ではない **W3Cノート** を公開することもできます。 W3Cノートの例には、ユースケースのリスト、ガイダンス、放棄された作業のステータスなどが含まれます。
 
-W3Cノートは[The Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track)もフォローします。それらは通常、ノートとして。**なんらかの改訂された公共作業ドラフトの出版** という段階です。
+W3Cノートは[The Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track)もフォローします。それらは通常、ノートとして。**なんらかの改訂された公共作業ドラフトの出版** という段階です。
 
 詳細は、[W3Cプロセスドキュメント](https://w3c.github.io/w3process/#Note)を参照してください。
 
-## Requirements for W3C Recommenations (Technical Reports)
+## Requirements for W3C Recommendations (Technical Reports)
 ## W3Cの勧告(技術報告書)に対する要求条件
-W3C勧告（Technical Reports）は、[勧告のフロー](#w3c-recommenation-technical-report-flow-the-recommendation-track)のあらゆる段階で公開される文書である。ドキュメントには、以下を含むセット情報が表示されます。
+W3C勧告（Technical Reports）は、[勧告のフロー](#w3c-recommendation-technical-report-flow-the-recommendation-track)のあらゆる段階で公開される文書である。ドキュメントには、以下を含むセット情報が表示されます。
 
-* ドキュメントの成熟度レベル([勧告のフロー](#w3c-recommenation-technical-report-flow-the-recommended-track)を参照)
+* ドキュメントの成熟度レベル([勧告のフロー](#w3c-recommendation-technical-report-flow-the-recommended-track)を参照)
 * 文書を作成したワーキンググループ
 * バグの記録方法と場所についての説明
 * このドキュメントの「次のステップ」
@@ -443,7 +443,7 @@ W3C勧告（Technical Reports）は、[勧告のフロー](#w3c-recommenation-te
 ワーキンググループが新しい標準またはW3Cノートで作業を開始することに合意したとき、作業ドラフトを作成する。ワーキングドラフトは新しい文書でも、ワーキンググループは[エディタードラフト](#editors-draft)を採用することもできます。これらの両方の移行は「最初の公開作業ドラフト」になる。この段階では、[W3Cの特許ポリシーに詳述されている"除外特許の呼びかけ"](https://www.w3.org/Consortium/Patent-Policy-20170801/#sec-exclude-mech)を始めます．
 ワーキンググループは引き続きこの文書の作業を続け、意思決定と文書の編集に合意し、「改訂作業ドラフト」を作成し続ける。文書に重大な変更が加えられた場合、その文書を[W3Cテクニカルレポートページ](https://www.w3.org/TR/)に再アップロードする必要があります。 6ヵ月経過しても変更がなければ、改訂作業ドラフトをアップロードする必要があります。この改訂案は、なぜこの時間内に変更がないのかを示しています。
 
-グループは、次の推奨トラックステージ([勧告フロー](#w3c-recommenation-technical-report-flow-the-recommended-track)および[遷移要求]を参照)への移行のために、作業ドラフトに関する情報を準備する必要があります。 （ステージとトランジションの詳細については、[勧告フロー](#w3c-recommenation-technical-report-flow-the-recommendation-track)と[遷移要求](#transition-requests-and-moving-between-track-stages)を参照してください。これらには、
+グループは、次の推奨トラックステージ([勧告フロー](#w3c-recommendation-technical-report-flow-the-recommended-track)および[遷移要求]を参照)への移行のために、作業ドラフトに関する情報を準備する必要があります。 （ステージとトランジションの詳細については、[勧告フロー](#w3c-recommendation-technical-report-flow-the-recommendation-track)と[遷移要求](#transition-requests-and-moving-between-track-stages)を参照してください。これらには、
 
 * 文書を進めるためのグループ決定の記録
 * 最後のバージョンからの変更の記録
@@ -457,7 +457,7 @@ W3C勧告（Technical Reports）は、[勧告のフロー](#w3c-recommenation-te
 作業草案は、「修正作業ドラフト」，[候補勧告](#candidate-recommendation)、または「作業グループノート」に移行することができます。
 
 ### 候補勧告
-候補勧告は、最終的なレビューがなされる文書である。この段階で、グループは文書を次の段階に進めるための一連の情報を準備する.トラックステージ間の遷移要求と移動のステージの詳細については([勧告フロー](#w3c-recommenation-technical-report-flow-the-recommendation-track)と[移行要求](#transition-requests-and-moving-between-track-stages)を参照してください。収集される情報は次のとおりです。
+候補勧告は、最終的なレビューがなされる文書である。この段階で、グループは文書を次の段階に進めるための一連の情報を準備する.トラックステージ間の遷移要求と移動のステージの詳細については([勧告フロー](#w3c-recommendation-technical-report-flow-the-recommendation-track)と[移行要求](#transition-requests-and-moving-between-track-stages)を参照してください。収集される情報は次のとおりです。
 
 * 文書がワーキンググループの要件([チャーター](#charter-and-call-for-participation)に概要が記載されている)に合致していることを説明する．または要件が変更されたのならその理由
 * 他の仕様への依存
@@ -492,7 +492,7 @@ W3C勧告（Technical Reports）は、[勧告のフロー](#w3c-recommenation-te
 
 ### W3C Recommendation
 ### W3C勧告
-W3C勧告は、W3Cの承認された標準であり、[W3C勧告トラック](#w3c-recommenation-technical-report-flow-the-recommendation-track)の終点です！ 「Rec」、「Recommendation」、「TR」、「Technical Report」、「Spec」、「Standard」を含むW3C勧告に使用される多くの非公式用語があります。そらはすべて同じことを意味します。
+W3C勧告は、W3Cの承認された標準であり、[W3C勧告トラック](#w3c-recommendation-technical-report-flow-the-recommendation-track)の終点です！ 「Rec」、「Recommendation」、「TR」、「Technical Report」、「Spec」、「Standard」を含むW3C勧告に使用される多くの非公式用語があります。そらはすべて同じことを意味します。
 
 W3C勧告に到達するには、「W3C決定」が必要です。これは、文書がすべての[遷移要求](#transition-requests-and-moving-between-track-stages)要件を満たし、[Director](#the director)が文書を承認し、文書が[提案された推薦](#proposed-recommendation)ステージ中の[ACレビュー](#ac-reviews)にパスすることが必要です．
 
@@ -553,11 +553,11 @@ W3Cまたは[ディレクター](#the-director)は、どの段階でもドラフ
 
 ワーキンググループが既に閉鎖されている場合、W3Cは変更を要求することができます。
 
-編集者の変更は、[Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommendation-track)の別の段階に戻ることなく進めることができます。 [実質的な変更](https://w3c.github.io/w3process/#substantive-change)は、文書が[候補勧告](#candidate-recommendation)に戻るように要求する，あるいはワーキンググループが存在しなくなった場合は「候補推奨勧告」になる。
+編集者の変更は、[Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommendation-track)の別の段階に戻ることなく進めることができます。 [実質的な変更](https://w3c.github.io/w3process/#substantive-change)は、文書が[候補勧告](#candidate-recommendation)に戻るように要求する，あるいはワーキンググループが存在しなくなった場合は「候補推奨勧告」になる。
 
 ワーキンググループが文書を編集した場合、その勧告は「編集された勧告」となる。 W3Cが変更を要求し完了した場合、その文書は「改訂された勧告」となる。
 
-[勧告トラック](#w3c-recommenation-technical-report-flow-the-recommendation-track)の各ステージと同様に、すべての[遷移要求]](#transition-requests-and-moving-between-track-stages)が改訂された推奨事項に適用されます。
+[勧告トラック](#w3c-recommendation-technical-report-flow-the-recommendation-track)の各ステージと同様に、すべての[遷移要求]](#transition-requests-and-moving-between-track-stages)が改訂された推奨事項に適用されます。
 
 ### Rescinded, Obsolete or Superseded Recommendations
 ### 撤廃されたまたは陳腐化した、または廃止された勧告
@@ -576,9 +576,9 @@ W3C勧告の一部のみを陳腐化、代替、または廃止する必要が�
 
 # Member Submissions
 # メンバーの文書提出
-メンバーはW3Cへの文書提出を行うことができます。これらの文書は、通常、ウェブに適用可能な技術または他のアイデアを詳述しています。これらの文書はW3Cの外部で開発されているため、W3C [Recommendation Track](#w3c-recommenation-technical-report-flow-the-recommended-track)を通過しておらず、[W3C勧告](#w3c-recommendation)ではありません。それらは将来の仕事の基礎になることができますが、これについての保証はありません。
+メンバーはW3Cへの文書提出を行うことができます。これらの文書は、通常、ウェブに適用可能な技術または他のアイデアを詳述しています。これらの文書はW3Cの外部で開発されているため、W3C [Recommendation Track](#w3c-recommendation-technical-report-flow-the-recommended-track)を通過しておらず、[W3C勧告](#w3c-recommendation)ではありません。それらは将来の仕事の基礎になることができますが、これについての保証はありません。
 
-会員提出は、今後開催される作業部会のための新しい作業提案書の作成を支援する良い方法です。ワーキンググループが既に存在する場合、技術はワーキンググループを通して通常どおり貢献され、メンバー提出ではなく[勧告フロー](#w3c-recommenation-technical-report-flow-the-recommendation-track)に従うことが望ましい。
+会員提出は、今後開催される作業部会のための新しい作業提案書の作成を支援する良い方法です。ワーキンググループが既に存在する場合、技術はワーキンググループを通して通常どおり貢献され、メンバー提出ではなく[勧告フロー](#w3c-recommendation-technical-report-flow-the-recommendation-track)に従うことが望ましい。
 
 複数のメンバーが文書を作成処理していたとしても、1人のメンバーのみがメンバー提出を行います。厳格なプロセスがメンバー提出に関与している場合は、[依頼要求に必要な情報](https://w3c.github.io/w3process/#SubmissionReqs)および[投稿者の権利](https： /w3c.github.io/w3process/#SubmissionRights)にあるW3Cのプロセス文書を参照して下さい。
 


### PR DESCRIPTION
Given how often this occurs in the document, I'm hoping this isn't just a word that I haven't come across before, but a Google Search for "W3C Recommenations" returns this document as the top hit, so I think it's just a typo!